### PR TITLE
Accept unknown keyword arguments from Job

### DIFF
--- a/actinia/job.py
+++ b/actinia/job.py
@@ -53,6 +53,8 @@ class Job:
         timestamp,
         urls,
         user_id,
+        queue,
+        **args
     ):
         self.name = name
         self.__actinia = actinia
@@ -71,6 +73,7 @@ class Job:
         self.timestamp = timestamp
         self.urls = urls
         self.user_id = user_id
+        self.queue = queue
 
     def __update(
         self,


### PR DESCRIPTION
We had a problem where Actinia sent us a response containing the key "queue", which was deserialized and unpacked as a keyword argument, which was not expected.

We now add a queue param as well as a dict that catches any other arguments that may appear.