### PR TITLE
Updated git organization references from 'mundialis' to 'actinia-org'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,24 +44,24 @@ Types of changes
 
 ## [0.1.0] - 2022-08-16
 ## Added
-* Location management and process chain validation by @anikaweinmann in https://github.com/mundialis/actinia-python-client/pull/2
-* Raster management by @anikaweinmann in https://github.com/mundialis/actinia-python-client/pull/5
-* Vector management by @anikaweinmann in https://github.com/mundialis/actinia-python-client/pull/6
+* Location management and process chain validation by @anikaweinmann in https://github.com/actinia-org/actinia-python-client/pull/2
+* Raster management by @anikaweinmann in https://github.com/actinia-org/actinia-python-client/pull/5
+* Vector management by @anikaweinmann in https://github.com/actinia-org/actinia-python-client/pull/6
 
 ## Documentation + CI
-* manual: add pages in list by @neteler in https://github.com/mundialis/actinia-python-client/pull/1
-* Add & use a task for installing dependencies by @marcjansen in https://github.com/mundialis/actinia-python-client/pull/7
-* Fix a typo of the program name in file headers by @marcjansen in https://github.com/mundialis/actinia-python-client/pull/8
-* manual: add Fork Me On GitHub Ribbon by @neteler in https://github.com/mundialis/actinia-python-client/pull/3
-* Enhance docs by @mmacata in https://github.com/mundialis/actinia-python-client/pull/9
+* manual: add pages in list by @neteler in https://github.com/actinia-org/actinia-python-client/pull/1
+* Add & use a task for installing dependencies by @marcjansen in https://github.com/actinia-org/actinia-python-client/pull/7
+* Fix a typo of the program name in file headers by @marcjansen in https://github.com/actinia-org/actinia-python-client/pull/8
+* manual: add Fork Me On GitHub Ribbon by @neteler in https://github.com/actinia-org/actinia-python-client/pull/3
+* Enhance docs by @mmacata in https://github.com/actinia-org/actinia-python-client/pull/9
 
 ## New Contributors
-* @neteler made their first contribution in https://github.com/mundialis/actinia-python-client/pull/1
-* @anikaweinmann made their first contribution in https://github.com/mundialis/actinia-python-client/pull/2
-* @marcjansen made their first contribution in https://github.com/mundialis/actinia-python-client/pull/7
-* @mmacata made their first contribution in https://github.com/mundialis/actinia-python-client/pull/9
+* @neteler made their first contribution in https://github.com/actinia-org/actinia-python-client/pull/1
+* @anikaweinmann made their first contribution in https://github.com/actinia-org/actinia-python-client/pull/2
+* @marcjansen made their first contribution in https://github.com/actinia-org/actinia-python-client/pull/7
+* @mmacata made their first contribution in https://github.com/actinia-org/actinia-python-client/pull/9
 
-**Full Changelog**: https://github.com/mundialis/actinia-python-client/compare/0.0.2...0.1.0
+**Full Changelog**: https://github.com/actinia-org/actinia-python-client/compare/0.0.2...0.1.0
 
 ### Added
 * First classes and method of actinia-python-client

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-[![image](https://img.shields.io/conda/vn/conda-forge/actinia-python-client.svg)](https://anaconda.org/conda-forge/actinia-python-client)
-
 # actinia-python-client
+
+[![image](https://img.shields.io/conda/vn/conda-forge/actinia-python-client.svg)](https://anaconda.org/conda-forge/actinia-python-client)
 
 Python Client Library for [actinia](https://actinia.mundialis.de/).
 
 ## Installation
 
-```
+```bash
 VERSION="0.3.0"
 
-pip3 install "actinia-python-client @ https://github.com/mundialis/actinia-python-client/releases/download/${VERSION}/actinia_python_client-${VERSION}-py3-none-any.whl"
+pip3 install "actinia-python-client @ https://github.com/actinia-org/actinia-python-client/releases/download/${VERSION}/actinia_python_client-${VERSION}-py3-none-any.whl"
 ```
-For newest version see [releases](https://github.com/mundialis/actinia-python-client/releases).
+
+For newest version see [releases](https://github.com/actinia-org/actinia-python-client/releases).
 
 ## Small Example
 

--- a/docs/docs/02_installation.md
+++ b/docs/docs/02_installation.md
@@ -3,6 +3,6 @@
 You can install the the actinia Python library via:
 ```
 VERSION="0.3.0"
-pip3 install "actinia-python-client @ https://github.com/mundialis/actinia-python-client/releases/download/${VERSION}/actinia_python_client-${VERSION}-py3-none-any.whl"
+pip3 install "actinia-python-client @ https://github.com/actinia-org/actinia-python-client/releases/download/${VERSION}/actinia_python_client-${VERSION}-py3-none-any.whl"
 ```
-For newest version see [releases](https://github.com/mundialis/actinia-python-client/releases).
+For newest version see [releases](https://github.com/actinia-org/actinia-python-client/releases).


### PR DESCRIPTION
I just updated the references from the old `mundialis` organization to the new `actinia-org` organization.