### PR TITLE
Add support for terminate job endpoint and unify request_and_check function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 88
 
 exclude = .git,__pycache__,env
 

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-max-line-length = 88
 
 exclude = .git,__pycache__,env
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Start containers
-      run: docker-compose -f "docker/docker-compose-test.yml" up -d --build
+      run: docker compose -f "docker/docker-compose-test.yml" up -d --build
     - name: List running docker
       run: docker ps
     - name: Running tests
       run: make test
     - name: Stop containers
-      run: docker-compose -f "docker/docker-compose-test.yml" down
+      run: docker compose -f "docker/docker-compose-test.yml" down

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-python-client"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
   { name="Anika Weinmann", email="weinmann@mundialis.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-python-client"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   { name="Anika Weinmann", email="weinmann@mundialis.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-python-client"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   { name="Anika Weinmann", email="weinmann@mundialis.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-python-client"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
   { name="Anika Weinmann", email="weinmann@mundialis.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-python-client"
-version = "0.3.1"
+version = "0.4.1"
 authors = [
   { name="Anika Weinmann", email="weinmann@mundialis.de" },
 ]

--- a/src/actinia/__init__.py
+++ b/src/actinia/__init__.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright 2022, mundialis GmbH & Co. KG"
 __maintainer__ = "Anika Weinmann"
 
 from pkg_resources import get_distribution, DistributionNotFound
-from actinia.actinia import Actinia
+from actinia.actinia import Actinia as Actinia
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/actinia/actinia.py
+++ b/src/actinia/actinia.py
@@ -70,7 +70,7 @@ class Actinia:
     def __check_version(self):
         version_url = f"{self.url}/version"
         data = request_and_check(
-            "GET", version_url, status_code=200, timeout=self.timeout
+            "GET", version_url, status_code=200, **{"timeout": self.timeout}
         )
 
         if len(data) > 2:
@@ -100,14 +100,12 @@ class Actinia:
         """
 
         version_url = f"{self.url}/version"
-        return request_and_check(
-            "GET", version_url, status_code=200, timeout=self.timeout
-        )
+        return request_and_check("GET", version_url, **{"timeout": self.timeout})
 
     def __check_auth(self):
         url = f"{self.url}/locations"
         request_and_check(
-            "GET", url, auth=(self.__auth), status_code=200, timeout=self.timeout
+            "GET", url, **{"timeout": self.timeout, "auth": (self.__auth)}
         )
         log.debug(f"{self.user} is logged in.")
 
@@ -147,7 +145,7 @@ class Actinia:
 
         url = f"{self.url}/locations"
         loc_names = request_and_check(
-            "GET", url, auth=(self.__auth), status_code=200, timeout=self.timeout
+            "GET", url, **{"timeout": self.timeout, "auth": (self.__auth)}
         )["locations"]
         loc = {lname: Location(lname, self, self.__auth) for lname in loc_names}
         self.locations = loc
@@ -168,11 +166,12 @@ class Actinia:
         request_and_check(
             "POST",
             url,
-            auth=(self.__auth),
-            headers=self.headers,
-            data=postbody,
-            status_code=200,
-            timeout=self.timeout,
+            **{
+                "timeout": self.timeout,
+                "auth": (self.__auth),
+                "headers": self.headers,
+                "data": postbody,
+            },
         )
 
         location = Location(name, self, self.__auth)

--- a/src/actinia/actinia.py
+++ b/src/actinia/actinia.py
@@ -69,9 +69,7 @@ class Actinia:
 
     def __check_version(self):
         version_url = f"{self.url}/version"
-        data = request_and_check(
-            "GET", version_url, status_code=200, **{"timeout": self.timeout}
-        )
+        data = request_and_check("GET", version_url, **{"timeout": self.timeout})
 
         if len(data) > 2:
             log.debug(f"{self.url} is working and will be used.")

--- a/src/actinia/actinia.py
+++ b/src/actinia/actinia.py
@@ -69,7 +69,9 @@ class Actinia:
 
     def __check_version(self):
         version_url = f"{self.url}/version"
-        data = request_and_check("GET", version_url, **{"timeout": self.timeout})
+        data = request_and_check(
+            "GET", version_url, **{"timeout": self.timeout}
+        )
 
         if len(data) > 2:
             log.debug(f"{self.url} is working and will be used.")
@@ -89,7 +91,9 @@ class Actinia:
                     self.api_version = "v1"
                     self.__check_version()
             else:
-                raise Exception(f"Connection to actinia server <{self.url}> failed!")
+                raise Exception(
+                    f"Connection to actinia server <{self.url}> failed!"
+                )
 
     def get_version(self):
         """
@@ -98,7 +102,9 @@ class Actinia:
         """
 
         version_url = f"{self.url}/version"
-        return request_and_check("GET", version_url, **{"timeout": self.timeout})
+        return request_and_check(
+            "GET", version_url, **{"timeout": self.timeout}
+        )
 
     def __check_auth(self):
         url = f"{self.url}/locations"
@@ -145,7 +151,9 @@ class Actinia:
         loc_names = request_and_check(
             "GET", url, **{"timeout": self.timeout, "auth": (self.__auth)}
         )["locations"]
-        loc = {lname: Location(lname, self, self.__auth) for lname in loc_names}
+        loc = {
+            lname: Location(lname, self, self.__auth) for lname in loc_names
+        }
         self.locations = loc
 
     def create_location(self, name, epsgcode):

--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -114,6 +114,9 @@ class Job:
     def terminate(self):
         """Terminate the current job"""
         kwargs = {"auth": self._Job__auth, "timeout": self.__actinia.timeout}
-        url = f"{self._Job__actinia.url}/resources/{self.user_id}/{self.resource_id}"
+        url = (
+            f"{self._Job__actinia.url}/resources/"
+            f"{self.user_id}/{self.resource_id}"
+        )
         request_and_check("DELETE", url, **kwargs)
         log.info("Termination request for job {self.resource_id} committed.")

--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -67,7 +67,7 @@ class Job:
             "timeout": self.__actinia.timeout,
         }
         url = self.urls["status"]
-        resp = request_and_check("GET", url, **kwargs)
+        resp = request_and_check("GET", url, status_code=(200, 400), **kwargs)
 
         if "process_results" not in resp:
             resp["process_results"] = {}

--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -92,7 +92,10 @@ class Job:
             self.poll(quiet=True)
             if self.status not in ["accepted", "running"]:
                 status_accepted_running = False
-                msg = f"Status of {self.name} job is {self.status}: " f"{self.message}"
+                msg = (
+                    f"Status of {self.name} job is {self.status}: "
+                    f"{self.message}"
+                )
                 if self.status in ["terminated", "error"]:
                     log.error(msg)
                     return 1
@@ -102,7 +105,10 @@ class Job:
             sleep(waiting_time)
             if self.status != status and not quiet:
                 status = self.status
-                msg = f"Status of {self.name} job is {self.status}: " f"{self.message}"
+                msg = (
+                    f"Status of {self.name} job is {self.status}: "
+                    f"{self.message}"
+                )
                 log.info(msg)
 
     def terminate(self):

--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -95,10 +95,7 @@ class Job:
             self.poll(quiet=True)
             if self.status not in ["accepted", "running"]:
                 status_accepted_running = False
-                msg = (
-                    f"Status of {self.name} job is {self.status}: "
-                    f"{self.message}"
-                )
+                msg = f"Status of {self.name} job is {self.status}: " f"{self.message}"
                 if self.status in ["terminated", "error"]:
                     log.error(msg)
                     return 1
@@ -108,15 +105,16 @@ class Job:
             sleep(waiting_time)
             if self.status != status and not quiet:
                 status = self.status
-                msg = (
-                    f"Status of {self.name} job is {self.status}: "
-                    f"{self.message}"
-                )
+                msg = f"Status of {self.name} job is {self.status}: " f"{self.message}"
                 log.info(msg)
 
-    # def terminate(self):
-    #     """
-    #     Terminate job.
-    #     """
-    #
-    # TODO
+    def terminate(self):
+        """Terminate the current job"""
+        kwargs = {"auth": self._Job__auth}
+        url = f"{self._Job__actinia.url}/resources/{self.user_id}/{self.resource_id}"
+        try:
+            actiniaResp = requests.delete(url, **kwargs, timeout=5)
+            actiniaResp.raise_for_status()
+        except requests.exceptions.ConnectionError as e:
+            raise e
+        log.info("Termination request for job {self.resource_id} committed.")

--- a/src/actinia/location.py
+++ b/src/actinia/location.py
@@ -36,7 +36,7 @@ from actinia.resources.logger import log
 from actinia.region import Region
 from actinia.mapset import Mapset
 from actinia.job import Job
-from actinia.utils import set_job_names
+from actinia.utils import set_job_names, request_and_check
 
 
 class Location:
@@ -56,11 +56,9 @@ class Location:
             raise Exception("Authentication is not set.")
 
         url = f"{self.__actinia.url}/locations/{self.name}/info"
-        resp = requests.get(url, auth=(self.__auth))
-        if resp.status_code != 200:
-            raise Exception(f"Error {resp.status_code}: {resp.text}")
-
-        proc_res = json.loads(resp.text)["process_results"]
+        proc_res = request_and_check(
+            url, (self.__auth), timeout=self.__actinia.timeout
+        )["process_results"]
         self.projection = proc_res["projection"]
         self.region = Region(**proc_res["region"])
 
@@ -86,9 +84,9 @@ class Location:
     def delete(self):
         """Delete a location via delete request."""
         url = f"{self.__actinia.url}/locations/{self.name}"
-        resp = requests.delete(url, auth=self.__auth)
-        if resp.status_code != 200:
-            raise Exception(f"Error {resp.status_code}: {resp.text}")
+        request_and_check(
+            "DELETE", url, auth=self.__auth, timeout=self.__actinia.timeout
+        )
         del self.__actinia.locations[self.name]
 
     def get_mapsets(self):
@@ -120,10 +118,8 @@ class Location:
         """
         if self.mapsets is None or len(self.mapsets) == 0:
             self.__request_mapsets()
-        Mapset.delete_mapset_request(
-            name, self.name, self.__actinia, self.__auth
-        )
-        if name is name in self.mapsets:
+        Mapset.delete_mapset_request(name, self.name, self.__actinia, self.__auth)
+        if name and name in self.mapsets:
             del self.mapsets[name]
         return self.mapsets
 
@@ -140,6 +136,7 @@ class Location:
             auth=self.__auth,
             headers=self.__actinia.headers,
             data=json.dumps(pc),
+            timeout=self.__actinia.timeout,
         )
         return resp
 
@@ -159,9 +156,7 @@ class Location:
         actiniaResp = self.__validate_process_chain(pc, "async")
         orig_name, name = set_job_names(name, "unknown_validation_job")
         if actiniaResp.status_code != 200:
-            raise Exception(
-                f"Error {actiniaResp.status_code}: {actiniaResp.text}"
-            )
+            raise Exception(f"Error {actiniaResp.status_code}: {actiniaResp.text}")
         resp = json.loads(actiniaResp.text)
         job = Job(orig_name, self.__actinia, self.__auth, resp)
         self.__actinia.jobs[name] = job
@@ -178,14 +173,13 @@ class Location:
         # set name
         orig_name, name = set_job_names(name)
         # set endpoint in url
-        url = (
-            f"{self.__actinia.url}/locations/{self.name}/"
-            "processing_async_export"
-        )
+        url = f"{self.__actinia.url}/locations/{self.name}/" "processing_async_export"
         # make POST request
-        postkwargs = dict()
-        postkwargs["headers"] = self.__actinia.headers
-        postkwargs["auth"] = self.__auth
+        postkwargs = {
+            "headers": self.__actinia.headers,
+            "auth": self.__auth,
+            "timeout": self.__actinia.timeout,
+        }
         if isinstance(pc, str):
             if os.path.isfile(pc):
                 with open(pc, "r") as pc_file:
@@ -197,12 +191,8 @@ class Location:
         else:
             raise Exception("Given process chain has no valid type.")
 
-        try:
-            actiniaResp = requests.post(url, **postkwargs)
-        except requests.exceptions.ConnectionError as e:
-            raise e
+        resp = request_and_check("POST", url, **postkwargs)
         # create a job
-        resp = json.loads(actiniaResp.text)
         job = Job(orig_name, self.__actinia, self.__auth, resp)
         self.__actinia.jobs[name] = job
         return job

--- a/src/actinia/location.py
+++ b/src/actinia/location.py
@@ -57,7 +57,9 @@ class Location:
 
         url = f"{self.__actinia.url}/locations/{self.name}/info"
         proc_res = request_and_check(
-            "GET", url, **{"auth": (self.__auth), "timeout": self.__actinia.timeout}
+            "GET",
+            url,
+            **{"auth": (self.__auth), "timeout": self.__actinia.timeout},
         )["process_results"]
         self.projection = proc_res["projection"]
         self.region = Region(**proc_res["region"])
@@ -85,7 +87,9 @@ class Location:
         """Delete a location via delete request."""
         url = f"{self.__actinia.url}/locations/{self.name}"
         request_and_check(
-            "DELETE", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+            "DELETE",
+            url,
+            **{"auth": self.__auth, "timeout": self.__actinia.timeout},
         )
         del self.__actinia.locations[self.name]
 

--- a/src/actinia/location.py
+++ b/src/actinia/location.py
@@ -122,7 +122,9 @@ class Location:
         """
         if self.mapsets is None or len(self.mapsets) == 0:
             self.__request_mapsets()
-        Mapset.delete_mapset_request(name, self.name, self.__actinia, self.__auth)
+        Mapset.delete_mapset_request(
+            name, self.name, self.__actinia, self.__auth
+        )
         if name and name in self.mapsets:
             del self.mapsets[name]
         return self.mapsets
@@ -160,7 +162,9 @@ class Location:
         actiniaResp = self.__validate_process_chain(pc, "async")
         orig_name, name = set_job_names(name, "unknown_validation_job")
         if actiniaResp.status_code != 200:
-            raise Exception(f"Error {actiniaResp.status_code}: {actiniaResp.text}")
+            raise Exception(
+                f"Error {actiniaResp.status_code}: {actiniaResp.text}"
+            )
         resp = json.loads(actiniaResp.text)
         job = Job(orig_name, self.__actinia, self.__auth, resp)
         self.__actinia.jobs[name] = job
@@ -177,7 +181,10 @@ class Location:
         # set name
         orig_name, name = set_job_names(name)
         # set endpoint in url
-        url = f"{self.__actinia.url}/locations/{self.name}/" "processing_async_export"
+        url = (
+            f"{self.__actinia.url}/locations/{self.name}/"
+            "processing_async_export"
+        )
         # make POST request
         postkwargs = {
             "headers": self.__actinia.headers,

--- a/src/actinia/location.py
+++ b/src/actinia/location.py
@@ -57,7 +57,7 @@ class Location:
 
         url = f"{self.__actinia.url}/locations/{self.name}/info"
         proc_res = request_and_check(
-            url, (self.__auth), timeout=self.__actinia.timeout
+            "GET", url, **{"auth": (self.__auth), "timeout": self.__actinia.timeout}
         )["process_results"]
         self.projection = proc_res["projection"]
         self.region = Region(**proc_res["region"])
@@ -85,7 +85,7 @@ class Location:
         """Delete a location via delete request."""
         url = f"{self.__actinia.url}/locations/{self.name}"
         request_and_check(
-            "DELETE", url, auth=self.__auth, timeout=self.__actinia.timeout
+            "DELETE", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
         )
         del self.__actinia.locations[self.name]
 

--- a/src/actinia/mapset.py
+++ b/src/actinia/mapset.py
@@ -154,7 +154,8 @@ class Mapset:
             "GET", url, **{"auth": auth, "timeout": actinia.timeout}
         )["process_results"]
         mapsets = {
-            mname: Mapset(mname, location_name, actinia, auth) for mname in mapset_names
+            mname: Mapset(mname, location_name, actinia, auth)
+            for mname in mapset_names
         }
         return mapsets
 
@@ -186,13 +187,17 @@ class Mapset:
             and text if request fails.
         """
         # check if mapset exists
-        existing_mapsets = cls.list_mapsets_request(location_name, actinia, auth)
+        existing_mapsets = cls.list_mapsets_request(
+            location_name, actinia, auth
+        )
         if mapset_name in existing_mapsets:
             log.warning(f"Mapset <{mapset_name}> already exists.")
             return existing_mapsets[mapset_name]
 
         url = cls.__request_url(actinia.url, location_name, mapset_name)
-        request_and_check("POST", url, **{"auth": (auth), "timeout": actinia.timeout})
+        request_and_check(
+            "POST", url, **{"auth": (auth), "timeout": actinia.timeout}
+        )
         return Mapset(mapset_name, location_name, actinia, auth)
 
     @classmethod
@@ -222,13 +227,19 @@ class Mapset:
             and text if request fails.
         """
         # check if mapset exists
-        existing_mapsets = cls.list_mapsets_request(location_name, actinia, auth)
+        existing_mapsets = cls.list_mapsets_request(
+            location_name, actinia, auth
+        )
         if mapset_name not in existing_mapsets:
-            log.warning(f"Mapset <{mapset_name}> does not exist and cannot be deleted.")
+            log.warning(
+                f"Mapset <{mapset_name}> does not exist and cannot be deleted."
+            )
             return None
 
         url = cls.__request_url(actinia.url, location_name, mapset_name)
-        request_and_check("DELETE", url, **{"auth": (auth), "timeout": actinia.timeout})
+        request_and_check(
+            "DELETE", url, **{"auth": (auth), "timeout": actinia.timeout}
+        )
         return None
 
     @classmethod

--- a/src/actinia/mapset.py
+++ b/src/actinia/mapset.py
@@ -276,7 +276,9 @@ class Mapset:
             f"mapsets/{self.name}/raster_layers"
         )
         raster_names = request_and_check(
-            "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+            "GET",
+            url,
+            **{"auth": self.__auth, "timeout": self.__actinia.timeout},
         )["process_results"]
         rasters = {
             mname: Raster(
@@ -309,7 +311,9 @@ class Mapset:
             f"mapsets/{self.name}/vector_layers"
         )
         vector_names = request_and_check(
-            "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+            "GET",
+            url,
+            **{"auth": self.__auth, "timeout": self.__actinia.timeout},
         )["process_results"]
         vectors = {
             mname: Vector(
@@ -345,7 +349,11 @@ class Mapset:
         resp_dict = request_and_check(
             "POST",
             url,
-            **{"auth": self.__auth, "files": files, "timeout": self.__actinia.timeout},
+            **{
+                "auth": self.__auth,
+                "files": files,
+                "timeout": self.__actinia.timeout,
+            },
         )
         job = Job(
             f"raster_upload_{self.__location_name}_{self.name}_{layer_name}",
@@ -373,7 +381,9 @@ class Mapset:
             f"mapsets/{self.name}/raster_layers/{layer_name}"
         )
         request_and_check(
-            "DELETE", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+            "DELETE",
+            url,
+            **{"auth": self.__auth, "timeout": self.__actinia.timeout},
         )
         if self.raster_layers is None:
             self.get_raster_layers()
@@ -397,7 +407,11 @@ class Mapset:
         resp_dict = request_and_check(
             "POST",
             url,
-            **{"files": files, "auth": self.__auth, "timeout": self.__actinia.timeout},
+            **{
+                "files": files,
+                "auth": self.__auth,
+                "timeout": self.__actinia.timeout,
+            },
         )
         job = Job(
             f"vector_upload_{self.__location_name}_{self.name}_{layer_name}",

--- a/src/actinia/mapset.py
+++ b/src/actinia/mapset.py
@@ -151,7 +151,7 @@ class Mapset:
         """
         url = cls.__request_url(actinia.url, location_name)
         mapset_names = request_and_check(
-            "GET", url, auth=auth, timeout=actinia.timeout
+            "GET", url, **{"auth": auth, "timeout": actinia.timeout}
         )["process_results"]
         mapsets = {
             mname: Mapset(mname, location_name, actinia, auth) for mname in mapset_names
@@ -192,7 +192,7 @@ class Mapset:
             return existing_mapsets[mapset_name]
 
         url = cls.__request_url(actinia.url, location_name, mapset_name)
-        request_and_check("POST", url, auth=(auth), timeout=actinia.timeout)
+        request_and_check("POST", url, **{"auth": (auth), "timeout": actinia.timeout})
         return Mapset(mapset_name, location_name, actinia, auth)
 
     @classmethod
@@ -228,7 +228,7 @@ class Mapset:
             return None
 
         url = cls.__request_url(actinia.url, location_name, mapset_name)
-        request_and_check("DELETE", url, auth=(auth), timeout=actinia.timeout)
+        request_and_check("DELETE", url, **{"auth": (auth), "timeout": actinia.timeout})
         return None
 
     @classmethod
@@ -261,9 +261,9 @@ class Mapset:
         url = cls.__request_url(
             actinia.url, location_name, mapset_name, MAPSET_TASK.INFO
         )
-        return request_and_check("GET", url, auth=(auth), timeout=actinia.timeout)[
-            "process_results"
-        ]
+        return request_and_check(
+            "GET", url, **{"auth": (auth), "timeout": actinia.timeout}
+        )["process_results"]
 
     def __request_raster_layers(self):
         """
@@ -276,7 +276,7 @@ class Mapset:
             f"mapsets/{self.name}/raster_layers"
         )
         raster_names = request_and_check(
-            "GET", url, auth=self.__auth, timeout=self.__actinia.timeout
+            "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
         )["process_results"]
         rasters = {
             mname: Raster(
@@ -309,7 +309,7 @@ class Mapset:
             f"mapsets/{self.name}/vector_layers"
         )
         vector_names = request_and_check(
-            "GET", url, auth=self.__auth, timeout=self.__actinia.timeout
+            "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
         )["process_results"]
         vectors = {
             mname: Vector(
@@ -343,7 +343,9 @@ class Mapset:
             f"mapsets/{self.name}/raster_layers/{layer_name}"
         )
         resp_dict = request_and_check(
-            "POST", url, auth=self.__auth, files=files, timeout=self.__actinia.timeout
+            "POST",
+            url,
+            **{"auth": self.__auth, "files": files, "timeout": self.__actinia.timeout},
         )
         job = Job(
             f"raster_upload_{self.__location_name}_{self.name}_{layer_name}",
@@ -371,7 +373,7 @@ class Mapset:
             f"mapsets/{self.name}/raster_layers/{layer_name}"
         )
         request_and_check(
-            "DELETE", url, auth=self.__auth, timeout=self.__actinia.timeout
+            "DELETE", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
         )
         if self.raster_layers is None:
             self.get_raster_layers()
@@ -395,9 +397,7 @@ class Mapset:
         resp_dict = request_and_check(
             "POST",
             url,
-            files=files,
-            auth=self.__auth,
-            timeout=self.__actinia.timeout,
+            **{"files": files, "auth": self.__auth, "timeout": self.__actinia.timeout},
         )
         job = Job(
             f"vector_upload_{self.__location_name}_{self.name}_{layer_name}",
@@ -427,8 +427,7 @@ class Mapset:
         request_and_check(
             "DELETE",
             url,
-            auth=self.__auth,
-            timeout=self.__actinia.timeout,
+            **{"auth": self.__auth, "timeout": self.__actinia.timeout},
         )
         if self.vector_layers is None:
             self.get_vector_layers()

--- a/src/actinia/raster.py
+++ b/src/actinia/raster.py
@@ -49,7 +49,9 @@ class Raster:
                 f"mapsets/{self.__mapset_name}/raster_layers/{self.name}"
             )
             r_info = request_and_check(
-                "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+                "GET",
+                url,
+                **{"auth": self.__auth, "timeout": self.__actinia.timeout},
             )["process_results"]
             self.info = r_info
 

--- a/src/actinia/raster.py
+++ b/src/actinia/raster.py
@@ -49,7 +49,7 @@ class Raster:
                 f"mapsets/{self.__mapset_name}/raster_layers/{self.name}"
             )
             r_info = request_and_check(
-                "GET", url, self.__auth, timeout=self.__actinia.timeout
+                "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
             )["process_results"]
             self.info = r_info
 

--- a/src/actinia/raster.py
+++ b/src/actinia/raster.py
@@ -48,8 +48,9 @@ class Raster:
                 f"{self.__actinia.url}/locations/{self.__location_name}/"
                 f"mapsets/{self.__mapset_name}/raster_layers/{self.name}"
             )
-            resp = request_and_check(url, self.__auth)
-            r_info = resp["process_results"]
+            r_info = request_and_check(
+                "GET", url, self.__auth, timeout=self.__actinia.timeout
+            )["process_results"]
             self.info = r_info
 
             self.region = Region(

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -48,7 +48,7 @@ def request_and_check(method, url, status_code=200, **kwargs):
 
     Throws an error if the request does not have the status_code
     """
-    resp = requests.request(method, url, **kwargs)  # auth=kwargs.get("auth"), timeout=kwargs.get("timeout"))
+    resp = requests.request(method, url, **kwargs)
     # Use resp.raise_for_status() ?
     if resp.status_code == 401:
         raise Exception("Wrong user or password. Please check your inputs.")

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -48,7 +48,7 @@ def request_and_check(method, url, status_code=200, **kwargs):
 
     Throws an error if the request does not have the status_code
     """
-    resp = requests.request(method, url, auth=kwargs["auth"], timeout=kwargs["timeout"])
+    resp = requests.request(method, url, **kwargs)  # auth=kwargs.get("auth"), timeout=kwargs.get("timeout"))
     # Use resp.raise_for_status() ?
     if resp.status_code == 401:
         raise Exception("Wrong user or password. Please check your inputs.")

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -38,10 +38,13 @@ def request_and_check(method, url, status_code=(200,), **kwargs):
     Parameters:
         method (string): Request method (GET, POST, PUT, DELETE, ...)
         url (string): URL as string
-        status_code (int): Status code to check if it is set; default is 200
-        auth (tuple): Tuple of user and password
-        timeout (tuple): Tuple of connection timeout and read timeout
-        headers (dict): Request headers
+        status_code (tuple): Tuple of acceptable status codes to check
+                             if it is set; default is 200
+        **kwargs:
+            auth (tuple): Tuple of user and password
+            timeout (tuple): Tuple of connection timeout and read timeout
+            headers (dict): Request headers
+            data (str): Request body to send (if needed)
 
     Returns:
         (dict): returns text of the response as dictionary

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -32,21 +32,27 @@ import requests
 from datetime import datetime
 
 
-def request_and_check(url, auth, status_code=200):
+def request_and_check(method, url, status_code=200, **kwargs):
     """Function to send a GET request to an URL and check the status code.
 
     Parameters:
+        method (string): Request method (GET, POST, PUT, DELETE, ...)
         url (string): URL as string
-        auth (tuple): Tupel of user and password
         status_code (int): Status code to check if it is set; default is 200
+        auth (tuple): Tuple of user and password
+        timeout (tuple): Tuple of connection timeout and read timeout
+        headers (dict): Request headers
 
     Returns:
         (dict): returns text of the response as dictionary
 
     Throws an error if the request does not have the status_code
     """
-    resp = requests.get(url, auth=auth)
-    if resp.status_code != status_code:
+    resp = requests.request(method, url, auth=kwargs["auth"], timeout=kwargs["timeout"])
+    # Use resp.raise_for_status() ?
+    if resp.status_code == 401:
+        raise Exception("Wrong user or password. Please check your inputs.")
+    elif resp.status_code != status_code:
         raise Exception(f"Error {resp.status_code}: {resp.text}")
     return json.loads(resp.text)
 

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -32,7 +32,7 @@ import requests
 from datetime import datetime
 
 
-def request_and_check(method, url, status_code=200, **kwargs):
+def request_and_check(method, url, status_code=(200), **kwargs):
     """Function to send a GET request to an URL and check the status code.
 
     Parameters:
@@ -52,7 +52,7 @@ def request_and_check(method, url, status_code=200, **kwargs):
     # Use resp.raise_for_status() ?
     if resp.status_code == 401:
         raise Exception("Wrong user or password. Please check your inputs.")
-    elif resp.status_code != status_code:
+    elif resp.status_code not in status_code:
         raise Exception(f"Error {resp.status_code}: {resp.text}")
     return json.loads(resp.text)
 

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -32,7 +32,7 @@ import requests
 from datetime import datetime
 
 
-def request_and_check(method, url, status_code=(200), **kwargs):
+def request_and_check(method, url, status_code=(200,), **kwargs):
     """Function to send a GET request to an URL and check the status code.
 
     Parameters:

--- a/src/actinia/vector.py
+++ b/src/actinia/vector.py
@@ -51,8 +51,9 @@ class Vector:
                 f"{self.__actinia.url}/locations/{self.__location_name}/"
                 f"mapsets/{self.__mapset_name}/vector_layers/{self.name}"
             )
-            resp = request_and_check(url, self.__auth)
-            v_info = resp["process_results"]
+            v_info = request_and_check(
+                "GET", url, self.__auth, timeout=self.__actinia.timeout
+            )["process_results"]
             self.info = v_info
 
             self.region = Region(

--- a/src/actinia/vector.py
+++ b/src/actinia/vector.py
@@ -52,7 +52,9 @@ class Vector:
                 f"mapsets/{self.__mapset_name}/vector_layers/{self.name}"
             )
             v_info = request_and_check(
-                "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
+                "GET",
+                url,
+                **{"auth": self.__auth, "timeout": self.__actinia.timeout},
             )["process_results"]
             self.info = v_info
 

--- a/src/actinia/vector.py
+++ b/src/actinia/vector.py
@@ -52,7 +52,7 @@ class Vector:
                 f"mapsets/{self.__mapset_name}/vector_layers/{self.name}"
             )
             v_info = request_and_check(
-                "GET", url, self.__auth, timeout=self.__actinia.timeout
+                "GET", url, **{"auth": self.__auth, "timeout": self.__actinia.timeout}
             )["process_results"]
             self.info = v_info
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,7 +51,9 @@ class TestActiniaUtils(object):
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version_fail"
         err_msg = "The requested URL was not found on the server."
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, status_code=(200,), **{"auth": ACTINIA_AUTH})
+            request_and_check(
+                "GET", url, status_code=(200,), **{"auth": ACTINIA_AUTH}
+            )
         assert err_msg in str(excinfo.value)
 
     def test_request_and_check_wrong_auth(self):
@@ -60,7 +62,9 @@ class TestActiniaUtils(object):
         err_msg = "Wrong user or password. Please check your inputs."
         wrong_auth = ("actinia-gdi", "wrong_pw")
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, status_code=(200,), **{"auth": wrong_auth})
+            request_and_check(
+                "GET", url, status_code=(200,), **{"auth": wrong_auth}
+            )
         assert err_msg in str(excinfo.value)
 
     def test_set_job_names(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,9 @@ class TestActiniaUtils(object):
     def test_request_and_check(self):
         """Test request_and_check utils function."""
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version"
-        resp = request_and_check("GET", url, ACTINIA_AUTH, status_code=200)
+        resp = request_and_check(
+            "GET", url, status_code=(200), **{"auth": ACTINIA_AUTH}
+        )
         assert "version" in resp
 
     def test_request_and_check_wrong_url(self):
@@ -49,7 +51,7 @@ class TestActiniaUtils(object):
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version_fail"
         err_msg = "The requested URL was not found on the server."
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, ACTINIA_AUTH, status_code=200)
+            request_and_check("GET", url, status_code=(200), **{"auth": ACTINIA_AUTH})
         assert err_msg in str(excinfo.value)
 
     def test_request_and_check_wrong_auth(self):
@@ -58,7 +60,7 @@ class TestActiniaUtils(object):
         err_msg = "Unauthorized Access"
         wrong_auth = ("actinia-gdi", "wrong_pw")
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, wrong_auth, status_code=200)
+            request_and_check("GET", url, status_code=(200), **{"auth": wrong_auth})
         assert err_msg in str(excinfo.value)
 
     def test_set_job_names(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,7 +42,7 @@ class TestActiniaUtils(object):
         """Test request_and_check utils function."""
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version"
         resp = request_and_check(
-            "GET", url, status_code=(200), **{"auth": ACTINIA_AUTH}
+            "GET", url, status_code=(200,), **{"auth": ACTINIA_AUTH}
         )
         assert "version" in resp
 
@@ -51,7 +51,7 @@ class TestActiniaUtils(object):
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version_fail"
         err_msg = "The requested URL was not found on the server."
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, status_code=(200), **{"auth": ACTINIA_AUTH})
+            request_and_check("GET", url, status_code=(200,), **{"auth": ACTINIA_AUTH})
         assert err_msg in str(excinfo.value)
 
     def test_request_and_check_wrong_auth(self):
@@ -60,7 +60,7 @@ class TestActiniaUtils(object):
         err_msg = "Unauthorized Access"
         wrong_auth = ("actinia-gdi", "wrong_pw")
         with pytest.raises(Exception) as excinfo:
-            request_and_check("GET", url, status_code=(200), **{"auth": wrong_auth})
+            request_and_check("GET", url, status_code=(200,), **{"auth": wrong_auth})
         assert err_msg in str(excinfo.value)
 
     def test_set_job_names(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,7 +57,7 @@ class TestActiniaUtils(object):
     def test_request_and_check_wrong_auth(self):
         """Test request_and_check utils function with wrong auth."""
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/locations"
-        err_msg = "Unauthorized Access"
+        err_msg = "Wrong user or password. Please check your inputs."
         wrong_auth = ("actinia-gdi", "wrong_pw")
         with pytest.raises(Exception) as excinfo:
             request_and_check("GET", url, status_code=(200,), **{"auth": wrong_auth})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,7 @@ class TestActiniaUtils(object):
     def test_request_and_check(self):
         """Test request_and_check utils function."""
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version"
-        resp = request_and_check(url, ACTINIA_AUTH, status_code=200)
+        resp = request_and_check("GET", url, ACTINIA_AUTH, status_code=200)
         assert "version" in resp
 
     def test_request_and_check_wrong_url(self):
@@ -49,7 +49,7 @@ class TestActiniaUtils(object):
         url = f"{ACTINIA_BASEURL}api/{ACTINIA_VERSION}/version_fail"
         err_msg = "The requested URL was not found on the server."
         with pytest.raises(Exception) as excinfo:
-            request_and_check(url, ACTINIA_AUTH, status_code=200)
+            request_and_check("GET", url, ACTINIA_AUTH, status_code=200)
         assert err_msg in str(excinfo.value)
 
     def test_request_and_check_wrong_auth(self):
@@ -58,7 +58,7 @@ class TestActiniaUtils(object):
         err_msg = "Unauthorized Access"
         wrong_auth = ("actinia-gdi", "wrong_pw")
         with pytest.raises(Exception) as excinfo:
-            request_and_check(url, wrong_auth, status_code=200)
+            request_and_check("GET", url, wrong_auth, status_code=200)
         assert err_msg in str(excinfo.value)
 
     def test_set_job_names(self):


### PR DESCRIPTION
This PR adds support for terminating jobs (which has not been implemented yet: https://github.com/actinia-org/actinia-python-client/blob/main/src/actinia/job.py#L117)

It also extends the `request_and_check` function so it can be used on all kinds of requests and thus across all modules...

I have not checked tested all cases yet...

We are looking at using the python client more actively in ETL worksflows with Apache Airflow. So we may add support for STRDS (and similar additions) as well... Though no time line for that yet...