### PR TITLE
Handle ReadTimeout from actinia with retries

### DIFF
--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -54,9 +54,13 @@ class Job:
         for key in actinia_json_dict:
             setattr(self, key, actinia_json_dict[key])
 
-    def poll(self, quiet=False):
+    def poll(self, quiet=False, retries=0):
         """
         Update job by polling.
+
+        Args:
+            quiet: Bool if the method should log process status
+            retries: Integer number of retries in case of ReadTimeout
         """
         if self.status not in ["accepted", "running"]:
             log.warning("The job is not running and can not be updated.")
@@ -67,7 +71,9 @@ class Job:
             "timeout": self.__actinia.timeout,
         }
         url = self.urls["status"]
-        resp = request_and_check("GET", url, status_code=(200, 400), **kwargs)
+        resp = request_and_check(
+            "GET", url, status_code=(200, 400), retries=retries, **kwargs
+        )
 
         if "process_results" not in resp:
             resp["process_results"] = {}
@@ -77,7 +83,7 @@ class Job:
         if not quiet:
             log.info(f"Status of {self.name} job is {self.status}.")
 
-    def poll_until_finished(self, waiting_time=5, quiet=False):
+    def poll_until_finished(self, waiting_time=5, quiet=False, retries=0):
         """
         Polling job until finished or error.
 
@@ -85,17 +91,15 @@ class Job:
             waiting_time: Time to wait in seconds for next poll
             quiet: Bool if the method should log each process status or only
                    changed
+            retries: Integer number of retries in case of ReadTimeout
         """
         status_accepted_running = True
         status = None
         while status_accepted_running:
-            self.poll(quiet=True)
+            self.poll(quiet=True, retries=retries)
             if self.status not in ["accepted", "running"]:
                 status_accepted_running = False
-                msg = (
-                    f"Status of {self.name} job is {self.status}: "
-                    f"{self.message}"
-                )
+                msg = f"Status of {self.name} job is {self.status}: {self.message}"
                 if self.status in ["terminated", "error"]:
                     log.error(msg)
                     return 1
@@ -105,18 +109,12 @@ class Job:
             sleep(waiting_time)
             if self.status != status and not quiet:
                 status = self.status
-                msg = (
-                    f"Status of {self.name} job is {self.status}: "
-                    f"{self.message}"
-                )
+                msg = f"Status of {self.name} job is {self.status}: {self.message}"
                 log.info(msg)
 
     def terminate(self):
         """Terminate the current job"""
         kwargs = {"auth": self._Job__auth, "timeout": self.__actinia.timeout}
-        url = (
-            f"{self._Job__actinia.url}/resources/"
-            f"{self.user_id}/{self.resource_id}"
-        )
+        url = f"{self._Job__actinia.url}/resources/{self.user_id}/{self.resource_id}"
         request_and_check("DELETE", url, **kwargs)
         log.info("Termination request for job {self.resource_id} committed.")

--- a/src/actinia/job.py
+++ b/src/actinia/job.py
@@ -99,7 +99,10 @@ class Job:
             self.poll(quiet=True, retries=retries)
             if self.status not in ["accepted", "running"]:
                 status_accepted_running = False
-                msg = f"Status of {self.name} job is {self.status}: {self.message}"
+                msg = (
+                    f"Status of {self.name} job is {self.status}: "
+                    f"{self.message}"
+                )
                 if self.status in ["terminated", "error"]:
                     log.error(msg)
                     return 1
@@ -109,12 +112,18 @@ class Job:
             sleep(waiting_time)
             if self.status != status and not quiet:
                 status = self.status
-                msg = f"Status of {self.name} job is {self.status}: {self.message}"
+                msg = (
+                    f"Status of {self.name} job is {self.status}: "
+                    f"{self.message}"
+                )
                 log.info(msg)
 
     def terminate(self):
         """Terminate the current job"""
         kwargs = {"auth": self._Job__auth, "timeout": self.__actinia.timeout}
-        url = f"{self._Job__actinia.url}/resources/{self.user_id}/{self.resource_id}"
+        url = (
+            f"{self._Job__actinia.url}/resources/"
+            f"{self.user_id}/{self.resource_id}"
+        )
         request_and_check("DELETE", url, **kwargs)
         log.info("Termination request for job {self.resource_id} committed.")

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -33,7 +33,7 @@ from datetime import datetime
 
 
 def request_and_check(method, url, status_code=(200,), retries=0, **kwargs):
-    """Send a request with given method to a URL and check the status code.
+    """Send a request with the given method to a URL and check the status code.
 
     Parameters:
         method (string): Request method (GET, POST, PUT, DELETE, ...)

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -32,14 +32,16 @@ import requests
 from datetime import datetime
 
 
-def request_and_check(method, url, status_code=(200,), **kwargs):
-    """Function to send a GET request to an URL and check the status code.
+def request_and_check(method, url, status_code=(200,), retries=0, **kwargs):
+    """Send a request with given method to a URL and check the status code.
 
     Parameters:
         method (string): Request method (GET, POST, PUT, DELETE, ...)
         url (string): URL as string
         status_code (tuple): Tuple of acceptable status codes to check
                              if it is set; default is 200
+        retries (int): Maximal number of retries in case of read timeouts
+            default is 0.
         **kwargs:
             auth (tuple): Tuple of user and password
             timeout (tuple): Tuple of connection timeout and read timeout
@@ -49,15 +51,34 @@ def request_and_check(method, url, status_code=(200,), **kwargs):
     Returns:
         (dict): returns text of the response as dictionary
 
-    Throws an error if the request does not have the status_code
+    Throws an error if the request does not have the status_code or
+    response content be paresd as JSON.
     """
-    resp = requests.request(method, url, **kwargs)
-    # Use resp.raise_for_status() ?
-    if resp.status_code == 401:
-        raise Exception("Wrong user or password. Please check your inputs.")
-    elif resp.status_code not in status_code:
-        raise Exception(f"Error {resp.status_code}: {resp.text}")
-    return json.loads(resp.text)
+    attempt = 0
+    while attempt <= retries:
+        attempt += 1
+        resp = requests.request(method, url, **kwargs)
+        try:
+            if resp.status_code not in status_code:
+                resp.raise_for_status()
+        except requests.exceptions.ReadTimeout as e:
+            if attempt >= retries:
+                raise e
+            continue
+        except requests.exceptions.RequestException as e:
+            if resp.status_code == 401:
+                raise Exception(
+                    "Wrong user or password. Please check your inputs."
+                ) from e
+            raise requests.exceptions.RequestException(
+                f"Error {resp.status_code}: {resp.text}", e
+            ) from None
+    try:
+        return json.loads(resp.text)
+    except json.JSONDecodeError:
+        raise RuntimeError(
+            "Invalid value returned. Cannot parse JSON from response:", resp.text
+        ) from None
 
 
 def set_job_names(name, default_name="unknown_job"):

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -51,8 +51,8 @@ def request_and_check(method, url, status_code=(200,), retries=0, **kwargs):
     Returns:
         (dict): returns text of the response as dictionary
 
-    Throws an error if the request does not have the status_code or
-    response content be paresd as JSON.
+    Throws an error if the request does not have the right status_code or
+    the response content cannot be paresd as JSON.
     """
     attempt = 0
     while attempt <= retries:

--- a/src/actinia/utils.py
+++ b/src/actinia/utils.py
@@ -77,7 +77,8 @@ def request_and_check(method, url, status_code=(200,), retries=0, **kwargs):
         return json.loads(resp.text)
     except json.JSONDecodeError:
         raise RuntimeError(
-            "Invalid value returned. Cannot parse JSON from response:", resp.text
+            "Invalid value returned. Cannot parse JSON from response:",
+            resp.text,
         ) from None
 
 


### PR DESCRIPTION
We occasionally experience _ReadTimeout_ from `actinia` under high ressource usage.

The asynchounous processing continues fine, but it takes too long to get a status response and the client throws an exception, leading us to restart a job that is already running. That is esp. unfortunate as it further increases the system load that is already high and may lead race conditions and other failures...

Instead of failing right away, it would be great to allow for retries in that case. For now, we do catch those cases in our local code, but it would of course be more meaningful to have it in the client....

This PR implements retries in case of ReadTimeout.
Happy to adjust the code as prefered...